### PR TITLE
Drop ellipsis for rlang + use `check_installed()` to install packages on the fly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,11 +26,11 @@ Depends:
     Matrix
 Imports: 
     dplyr,
-    ellipsis,
     ggplot2,
     glue,
     igraph,
     methods,
+    rlang (>= 1.0.0),
     RSpectra,
     stats,
     tibble,

--- a/R/directed_factor_model.R
+++ b/R/directed_factor_model.R
@@ -5,7 +5,7 @@ new_directed_factor_model <- function(
   ...,
   subclass = character()) {
 
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
 
   n <- nrow(X)
   k1 <- ncol(X)

--- a/R/expected-degrees.R
+++ b/R/expected-degrees.R
@@ -69,7 +69,7 @@
 #' svds(dfm)
 #'
 expected_edges <- function(factor_model, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   UseMethod("expected_edges")
 }
 

--- a/R/expected-spectra.R
+++ b/R/expected-spectra.R
@@ -21,12 +21,7 @@ eigs_sym.undirected_factor_model <- function(
     opts = list(),
     ...) {
 
-  if (!requireNamespace("RSpectra", quietly = TRUE)) {
-    stop(
-      "Must install `RSpectra` for this functionality.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("RSpectra")
 
   Ax <- function(x, args) as.numeric(args$X %*% (args$SXt %*% x))
 
@@ -50,12 +45,7 @@ svds.undirected_factor_model <- function(
     opts = list(),
     ...) {
 
-  if (!requireNamespace("RSpectra", quietly = TRUE)) {
-    stop(
-      "Must install `RSpectra` for this functionality.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("RSpectra")
 
   Ax <- function(x, args) {
     as.numeric(args$X %*% (tcrossprod(args$S, args$X) %*% x))
@@ -95,12 +85,7 @@ svds.directed_factor_model <- function(
     opts = list(),
     ...) {
 
-  if (!requireNamespace("RSpectra", quietly = TRUE)) {
-    stop(
-      "Must install `RSpectra` for this functionality.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("RSpectra")
 
   Ax <- function(x, args) {
     as.numeric(args$X %*% (tcrossprod(args$S, args$Y) %*% x))

--- a/R/sample_edgelist.R
+++ b/R/sample_edgelist.R
@@ -146,7 +146,7 @@
 sample_edgelist <- function(
   factor_model,
   ...) {
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
   UseMethod("sample_edgelist")
 }
 

--- a/R/sample_igraph.R
+++ b/R/sample_igraph.R
@@ -28,7 +28,7 @@ sample_igraph <- function(
   factor_model,
   ...) {
 
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
 
   if (!(requireNamespace("igraph", quietly = TRUE))) {
     stop(

--- a/R/sample_igraph.R
+++ b/R/sample_igraph.R
@@ -30,13 +30,7 @@ sample_igraph <- function(
 
   rlang::check_dots_unnamed()
 
-  if (!(requireNamespace("igraph", quietly = TRUE))) {
-    stop(
-      "Must install `igraph` package to return graphs as `igraph` ",
-      "objects",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("igraph", "to return graphs as `igraph` objects.")
 
   UseMethod("sample_igraph")
 }

--- a/R/sample_sparse.R
+++ b/R/sample_sparse.R
@@ -24,7 +24,7 @@
 sample_sparse <- function(
   factor_model,
   ...) {
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
   UseMethod("sample_sparse")
 }
 

--- a/R/sample_tidygraph.R
+++ b/R/sample_tidygraph.R
@@ -28,7 +28,7 @@ sample_tidygraph <- function(
   factor_model,
   ...) {
 
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
 
   if (!(requireNamespace("tidygraph", quietly = TRUE))) {
     stop(

--- a/R/sample_tidygraph.R
+++ b/R/sample_tidygraph.R
@@ -30,13 +30,7 @@ sample_tidygraph <- function(
 
   rlang::check_dots_unnamed()
 
-  if (!(requireNamespace("tidygraph", quietly = TRUE))) {
-    stop(
-      "Must install `tidygraph` package to return graphs as `tidygraph` ",
-      "objects",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("igraph", "to return graphs as `tidygraph` objects.")
 
   UseMethod("sample_tidygraph")
 }

--- a/R/undirected_factor_model.R
+++ b/R/undirected_factor_model.R
@@ -5,7 +5,7 @@ new_undirected_factor_model <- function(
   allow_self_loops = TRUE,
   subclass = character()) {
 
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
 
   n <- nrow(X)
   k <- ncol(S)


### PR DESCRIPTION
Since it is superseded.https://rlang.r-lib.org/news/#argument-intake-1-0-0

I also took the oportunity to use `rlang::check_installed()` to handle missing suggests.

https://rlang.r-lib.org/reference/is_installed.html

It gives a nice interface that enables installing missing packages instead of getting an error